### PR TITLE
Issue #21

### DIFF
--- a/include/geos/CostEstimator/CostEstimatorOptions.h
+++ b/include/geos/CostEstimator/CostEstimatorOptions.h
@@ -17,29 +17,29 @@
 
 #include <vector>
 
+/// \brief List of analysis methods
+enum CostAnalysisKind {
+  RegisterUse, InstructionCache, StaticInstruction, TTIInstruction, Branch, 
+  Call, RandomCost
+};
+
+/// \brief This structure contain a vector with analysis and options for 
+/// them. It is used to inform to the CostEstimator how and which analysis 
+/// do.
+typedef struct CostEstimatorOptions {
+  double BranchMispredictionFrequency = 0.1; 
+  double BranchMispredictionCost = 40; 
+  double CPUClockInGHz = 1;
+
+  std::vector<CostAnalysisKind> AnalysisActivated;
+} CostEstimatorOptions;
+
+/// \brief List of groups of analysis.
+enum CostEstimatorOptionsSet {
+  NonArchSensitive, ArchSensitive
+};
+
 namespace {
-  /// \brief List of analysis methods
-  enum CostAnalysisKind {
-    RegisterUse, InstructionCache, StaticInstruction, TTIInstruction, Branch, 
-    Call, RandomCost
-  };
-
-  /// \brief This structure contain a vector with analysis and options for 
-  /// them. It is used to inform to the CostEstimator how and which analysis 
-  /// do.
-  typedef struct CostEstimatorOptions {
-    double BranchMispredictionFrequency = 0.1; 
-    double BranchMispredictionCost = 40; 
-    double CPUClockInGHz = 1;
-
-    std::vector<CostAnalysisKind> AnalysisActivated;
-  } CostEstimatorOptions;
-
-  /// \brief List of groups of analysis.
-  enum CostEstimatorOptionsSet {
-     NonArchSensitive, ArchSensitive
-  };
-
   /// \brief Given a type of group of analysis it returns a vector with all the 
   /// analysis from this group.
   std::vector<CostAnalysisKind> getAnalysisFor(CostEstimatorOptionsSet S) {
@@ -47,11 +47,11 @@ namespace {
       default:
       case NonArchSensitive:
         return {CostAnalysisKind::StaticInstruction, 
-            CostAnalysisKind::Call, CostAnalysisKind::Branch};
+          CostAnalysisKind::Call, CostAnalysisKind::Branch};
       case ArchSensitive:
         return {CostAnalysisKind::TTIInstruction, 
-            CostAnalysisKind::Call, CostAnalysisKind::Branch, 
-            CostAnalysisKind::RegisterUse};  
+          CostAnalysisKind::Call, CostAnalysisKind::Branch, 
+          CostAnalysisKind::RegisterUse};  
     }
   } 
 }

--- a/include/geos/ProfileModule/PassSequence.h
+++ b/include/geos/ProfileModule/PassSequence.h
@@ -23,6 +23,8 @@
 #include "geos/EnumString.h"
 
 #include <stdio.h>
+#include <random>
+#include <numeric>
 #include <vector>
 #include <unordered_map>
 #include <cctype>


### PR DESCRIPTION
An include to the _std_ random library was missing inside "geos/ProfileModule/PassSequence.h" (not sure why GCC 5.3.0 didn't complained).

Also, there were some warnings due to virtual functions "used but not defined". Turns out that it happens when the signature of a member function of a class depends on some class defined in an anonymous namespace (as that class "only exists there").