### PR TITLE
Nameless function bb

### DIFF
--- a/include/geos/CostEstimator/CostAnalysis.h
+++ b/include/geos/CostEstimator/CostAnalysis.h
@@ -27,7 +27,7 @@ class CostAnalysis {
     /// \param The parameters are the name of the function, the ProfileModule, 
     /// and the options.
     virtual double 
-      estimateCost(llvm::StringRef, const ProfileModule*,
+      estimateCost(llvm::Function&, const ProfileModule*,
           CostEstimatorOptions) const = 0;
     virtual ~CostAnalysis() {}
 };
@@ -43,7 +43,7 @@ class RegisterUseAnalysis : public CostAnalysis {
     RegisterUseAnalysis(const ProfileModule*);
     ~RegisterUseAnalysis();
     double 
-      estimateCost(llvm::StringRef, const ProfileModule*, 
+      estimateCost(llvm::Function&, const ProfileModule*, 
           CostEstimatorOptions) const;
 };
 
@@ -58,7 +58,7 @@ class InstructionCacheAnalysis : public CostAnalysis {
     InstructionCacheAnalysis(const ProfileModule*);
     ~InstructionCacheAnalysis();
     double 
-      estimateCost(llvm::StringRef, const ProfileModule*, 
+      estimateCost(llvm::Function&, const ProfileModule*, 
           CostEstimatorOptions) const;
 };
 
@@ -67,7 +67,7 @@ class InstructionCacheAnalysis : public CostAnalysis {
 class StaticInstructionAnalysis : public CostAnalysis {
   public:
     double 
-      estimateCost(llvm::StringRef, const ProfileModule*, 
+      estimateCost(llvm::Function&, const ProfileModule*, 
           CostEstimatorOptions) const;
 };
 
@@ -78,7 +78,7 @@ class TTIInstructionAnalysis : public CostAnalysis {
     TTIInstructionAnalysis();
     ~TTIInstructionAnalysis();
     double 
-      estimateCost(llvm::StringRef, const ProfileModule*, 
+      estimateCost(llvm::Function&, const ProfileModule*, 
           CostEstimatorOptions) const;
 };
 
@@ -87,7 +87,7 @@ class TTIInstructionAnalysis : public CostAnalysis {
 class BranchAnalysis : public CostAnalysis {
   public:
     double 
-      estimateCost(llvm::StringRef, const ProfileModule*, 
+      estimateCost(llvm::Function&, const ProfileModule*, 
           CostEstimatorOptions) const;
 };
 
@@ -96,7 +96,7 @@ class BranchAnalysis : public CostAnalysis {
 class CallAnalysis : public CostAnalysis {
   public:
     double 
-      estimateCost(llvm::StringRef, const ProfileModule*,
+      estimateCost(llvm::Function&, const ProfileModule*,
           CostEstimatorOptions) const;
 };
 
@@ -104,7 +104,7 @@ class CallAnalysis : public CostAnalysis {
 class RandomAnalysis : public CostAnalysis {
   public:
     double 
-      estimateCost(llvm::StringRef, const ProfileModule*,
+      estimateCost(llvm::Function&, const ProfileModule*,
           CostEstimatorOptions) const;
 };
 

--- a/include/geos/ProfileModule/ProfileModule.h
+++ b/include/geos/ProfileModule/ProfileModule.h
@@ -38,7 +38,7 @@ class ProfileModule {
     /// estimate and update its execution frequency. 
     uint64_t getExecutionFreqUsingSuccessors(llvm::BasicBlock *BB);
   public:
-    std::unordered_map<std::string, uint64_t> BBFreq;
+    std::unordered_map<llvm::BasicBlock*, uint64_t> BBFreq;
     std::vector<std::string> Argv;
 
     /// \brief If this class has been optimized this function will return the
@@ -128,8 +128,12 @@ class ProfileModule {
     /// \brief Returns its LLVM Module.
     llvm::Module* getLLVMModule() const;
 
-    /// \brief Make a copy of the Profiling Module.
-    ProfileModule* getCopy() const;
+    /// \brief Sets the @a llvm::Module.
+    void setLLVMModule(llvm::Module*);
+
+    /// \brief Make a copy of the Profiling Module. If @a Clone is true,
+    /// the @a llvm::Module owned is also copied.
+    ProfileModule* getCopy(bool Clone = true) const;
 
     /// \brief It saves the LLVM module with all the profiling information
     /// in the given path.

--- a/src/CostEstimator/CostAnalysis/Branch/BranchAnalysis.cpp
+++ b/src/CostEstimator/CostAnalysis/Branch/BranchAnalysis.cpp
@@ -18,18 +18,17 @@
 
 using namespace llvm;
 
-double BranchAnalysis::estimateCost(StringRef FuncName, 
+double BranchAnalysis::estimateCost(Function &Func, 
     const ProfileModule* Profile, CostEstimatorOptions Opts) const {
 
   double Cost = 0;
 
   auto M = Profile->getLLVMModule();
-  auto Func = M->getFunction(FuncName);
 
   double BranchMispredictionWeight = Opts.BranchMispredictionFrequency *
     Opts.BranchMispredictionCost;
 
-  for (auto &BB : *Func) {
+  for (auto &BB : Func) {
     auto Terminator = BB.getTerminator();              
     if (isa<IndirectBrInst>(Terminator)) { 
       Cost += (Profile->getBasicBlockFrequency(BB) * 

--- a/src/CostEstimator/CostAnalysis/Cache/InstructionCacheAnalysis.cpp
+++ b/src/CostEstimator/CostAnalysis/Cache/InstructionCacheAnalysis.cpp
@@ -255,9 +255,9 @@ InstructionCacheAnalysis::~InstructionCacheAnalysis() {
   delete PM;
 }
 
-double InstructionCacheAnalysis::estimateCost(StringRef FuncName, 
+double InstructionCacheAnalysis::estimateCost(Function &Func, 
     const ProfileModule *Profile, CostEstimatorOptions Opts) const {
 
   Module *M = PModule->getLLVMModule();
-  return MICA->getFunctionCost(*(M->getFunction(FuncName))) * 0.25;
+  return MICA->getFunctionCost(Func) * 0.25;
 }

--- a/src/CostEstimator/CostAnalysis/Cache/RegisterUseAnalysis.cpp
+++ b/src/CostEstimator/CostAnalysis/Cache/RegisterUseAnalysis.cpp
@@ -79,10 +79,9 @@ RegisterUseAnalysis::~RegisterUseAnalysis() {
   delete PM;
 }
 
-double RegisterUseAnalysis::estimateCost(StringRef FuncName, 
+double RegisterUseAnalysis::estimateCost(Function &Func, 
     const ProfileModule *Profile, CostEstimatorOptions Opts) const {
 
   Module   *M = PModule->getLLVMModule();
-  Function *F = M->getFunction(FuncName);
-  return MRU->getFunctionCost(*F) * 0.25;
+  return MRU->getFunctionCost(Func) * 0.25;
 }

--- a/src/CostEstimator/CostAnalysis/Call/CallCostAnalysis.cpp
+++ b/src/CostEstimator/CostAnalysis/Call/CallCostAnalysis.cpp
@@ -20,15 +20,14 @@
 
 using namespace llvm;
 
-double CallAnalysis::estimateCost(StringRef FuncName, 
+double CallAnalysis::estimateCost(Function &Func, 
     const ProfileModule* Profile, CostEstimatorOptions Opts) const {
 
   double Cost = 0;
 
   auto M = Profile->getLLVMModule();
-  auto Func = M->getFunction(FuncName);
 
-  for (auto &BB : *Func) {
+  for (auto &BB : Func) {
     double BBCost = 0; 
     for (auto &I : BB) {
       if (isa<CallInst>(I)) { 

--- a/src/CostEstimator/CostAnalysis/Instruction/StaticCost/StaticCostEstimator.cpp
+++ b/src/CostEstimator/CostAnalysis/Instruction/StaticCost/StaticCostEstimator.cpp
@@ -18,15 +18,14 @@
 
 using namespace llvm;
 
-double StaticInstructionAnalysis::estimateCost(StringRef FuncName, 
+double StaticInstructionAnalysis::estimateCost(Function &Func, 
     const ProfileModule* Profile, CostEstimatorOptions Opts) const {
 
   double Cost = 0;
 
   auto M = Profile->getLLVMModule();
-  auto Func = M->getFunction(FuncName);
 
-  for (auto &BB : *Func) {
+  for (auto &BB : Func) {
     double BBCost = 0; 
 
     for (auto &I : BB)

--- a/src/CostEstimator/CostAnalysis/Instruction/TTI/TTIInstructionAnalysis.cpp
+++ b/src/CostEstimator/CostAnalysis/Instruction/TTI/TTIInstructionAnalysis.cpp
@@ -37,13 +37,12 @@ TTIInstructionAnalysis::~TTIInstructionAnalysis() {
   FPM = nullptr;
 }
 
-double TTIInstructionAnalysis::estimateCost(StringRef FuncName, 
+double TTIInstructionAnalysis::estimateCost(Function &Func, 
     const ProfileModule* Profile, CostEstimatorOptions Opts) const {
 
   double Cost = 0;
 
   auto M = Profile->getLLVMModule();
-  auto Func = M->getFunction(FuncName);
 
   if (FPM == nullptr) { 
     FPM = new legacy::FunctionPassManager(M);
@@ -51,9 +50,9 @@ double TTIInstructionAnalysis::estimateCost(StringRef FuncName,
     FPM->doInitialization(); 
   }
 
-  FPM->run(*Func);
+  FPM->run(Func);
 
-  for (auto &BB : *Func) {
+  for (auto &BB : Func) {
     double BBCost = 0; 
 
     for (auto &I : BB) {

--- a/src/CostEstimator/CostAnalysis/Random/RandomCost.cpp
+++ b/src/CostEstimator/CostAnalysis/Random/RandomCost.cpp
@@ -15,19 +15,18 @@
 
 using namespace llvm;
 
-double RandomAnalysis::estimateCost(StringRef FuncName, 
+double RandomAnalysis::estimateCost(Function &Func, 
     const ProfileModule* Profile, CostEstimatorOptions Opts) const {
 
   double Cost = 0;
 
   auto M = Profile->getLLVMModule();
-  auto Func = M->getFunction(FuncName);
 
   std::random_device Rd;
   std::default_random_engine E1(Rd());
   std::uniform_int_distribution<int> uniform_dist(1, 4);
 
-  for (auto &BB : *Func) 
+  for (auto &BB : Func) 
     Cost += uniform_dist(E1) * Profile->getBasicBlockFrequency(BB);
   
   return Cost / Opts.CPUClockInGHz;

--- a/src/CostEstimator/CostEstimator.cpp
+++ b/src/CostEstimator/CostEstimator.cpp
@@ -30,7 +30,7 @@ CostEstimator::getModuleCost(const ProfileModule *Profile,
       createCostAnalysis(AnalysisKind, Profile);
     
     for (auto &Func : *Profile->getLLVMModule())
-      CostEstimated += Analyse->estimateCost(Func.getName(), Profile, Opts);
+      CostEstimated += Analyse->estimateCost(Func, Profile, Opts);
   }
 
   return CostEstimated / (Opts.CPUClockInGHz * std::pow(10, 9));
@@ -46,7 +46,8 @@ CostEstimator::getFunctionCost(StringRef FuncName, const ProfileModule *Profile,
     std::unique_ptr<CostAnalysis> Analyse = 
       createCostAnalysis(AnalysisKind, Profile);
 
-    CostEstimated += Analyse->estimateCost(FuncName, Profile, Opts);
+    llvm::Function *F = Profile->getLLVMModule()->getFunction(FuncName);
+    CostEstimated += Analyse->estimateCost(*F, Profile, Opts);
   }
 
   return CostEstimated / (Opts.CPUClockInGHz * std::pow(10, 9));

--- a/src/GEOS.cpp
+++ b/src/GEOS.cpp
@@ -115,7 +115,6 @@ GEOS::applyPasses(const std::shared_ptr<ProfileModule> PModule,
     ProfileModule *ModuleCopy = new ProfileModule(MyModule);
     ModuleCopy->Argv.insert(ModuleCopy->Argv.begin(), 
         PModule->Argv.begin(), PModule->Argv.end());
-    ModuleCopy->BBFreq.insert(PModule->BBFreq.begin(), PModule->BBFreq.end());
     ModuleCopy->repairProfiling();
     ModuleCopy->setPasses(PS);
     return std::shared_ptr<ProfileModule>(ModuleCopy);

--- a/src/ProfileModule/ProfileModule.cpp
+++ b/src/ProfileModule/ProfileModule.cpp
@@ -153,6 +153,9 @@ void
 ProfileModule::setBasicBlockFrequency(BasicBlock &BB, uint64_t Freq) {
   if (hasBasicBlockFrequency(BB)) BBFreq[&BB] = Freq;
   else BBFreq.insert(std::make_pair(&BB, Freq));
+
+  for (auto &I : BB)
+    setInstructionFrequency(I, Freq); 
 }
 
 bool ProfileModule::hasCallCost(const CallInst &I) const {
@@ -317,8 +320,6 @@ ProfileModule* ProfileModule::getCopy(bool Clone) const {
 
   if (!Argv.empty())
     NewPM->Argv.insert(NewPM->Argv.begin(), Argv.begin(), Argv.end());
-  if (!BBFreq.empty())
-    NewPM->BBFreq.insert(BBFreq.begin(), BBFreq.end());
   return NewPM;
 }
 

--- a/src/Profiling/ExecutionFrequency/GCOV/GCOVReader.cpp
+++ b/src/Profiling/ExecutionFrequency/GCOV/GCOVReader.cpp
@@ -92,8 +92,6 @@ void loadGCOV(std::vector<MemoryBuffer*> GCDAs,
       ++MBB;
       for(auto &BB : *LLVMFunc) {
         Profile->setBasicBlockFrequency(BB, (*MBB).getCount());  
-        for (auto &I : BB)
-          Profile->setInstructionFrequency(I, (*MBB).getCount());
 
         (*MBB).sortDstEdges();
         std::vector<uint32_t> Freqs;


### PR DESCRIPTION
These changes fix the "nameless Functions and BasicBlocks" problem.

When applying some optimizations (sorry, I don't remember which ones), the functions can be replaced by nameless functions (they become global temporary variables). As GEOS depended on their names, it couldn't analyse its cost.

Makes sense to preserve the "BBFreq" map inside "ProfileModule". Even though cloning invalidates all "BasicBlock" pointers, there has to be some kind of mapping from basic blocks and its frequency.

Also, added a "setLLVMModule" at "ProfileModule" class.